### PR TITLE
Refactor ToPascalCase method into StringExtensions

### DIFF
--- a/src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.cs
+++ b/src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
-using System.Text;
 using System.Text.Json;
 
 namespace PdfSmith.BusinessLayer.Extensions;
@@ -18,7 +17,7 @@ public static class JsonDocumentExtensions
             var expando = new ExpandoObject() as IDictionary<string, object>;
             foreach (var property in element.EnumerateObject())
             {
-                expando[ToPascalCase(property.Name)] = ConvertValue(property.Value)!;
+                expando[property.Name.ToPascalCase()] = ConvertValue(property.Value)!;
             }
 
             return (ExpandoObject)expando!;
@@ -70,38 +69,6 @@ public static class JsonDocumentExtensions
 
             return value;
         }
-    }
-
-    private static string ToPascalCase(string input)
-    {
-        if (string.IsNullOrEmpty(input))
-        {
-            return input;
-        }
-
-        var sb = new StringBuilder();
-        var capitalizeNext = true;
-
-        foreach (var c in input)
-        {
-            if (c is '_' or '-' or '.')
-            {
-                capitalizeNext = true;
-                continue;
-            }
-
-            if (capitalizeNext)
-            {
-                sb.Append(char.ToUpper(c));
-                capitalizeNext = false;
-            }
-            else
-            {
-                sb.Append(c);
-            }
-        }
-
-        return sb.ToString();
     }
 }
 

--- a/src/PdfSmith.BusinessLayer/Extensions/StringExtensions.cs
+++ b/src/PdfSmith.BusinessLayer/Extensions/StringExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+
+namespace PdfSmith.BusinessLayer.Extensions;
+
+public static class StringExtensions
+{
+    public static string ToPascalCase(this string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        var sb = new StringBuilder();
+        var capitalizeNext = true;
+
+        foreach (var c in input)
+        {
+            if (c is '_' or '-' or '.')
+            {
+                capitalizeNext = true;
+                continue;
+            }
+
+            if (capitalizeNext)
+            {
+                sb.Append(char.ToUpper(c));
+                capitalizeNext = false;
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/PdfSmith.BusinessLayer/Extensions/StringExtensions.cs
+++ b/src/PdfSmith.BusinessLayer/Extensions/StringExtensions.cs
@@ -11,7 +11,7 @@ public static class StringExtensions
             return input;
         }
 
-        var sb = new StringBuilder();
+        var sb = new StringBuilder(input.Length);
         var capitalizeNext = true;
 
         foreach (var c in input)
@@ -24,7 +24,7 @@ public static class StringExtensions
 
             if (capitalizeNext)
             {
-                sb.Append(char.ToUpper(c));
+                sb.Append(char.ToUpperInvariant(c));
                 capitalizeNext = false;
             }
             else


### PR DESCRIPTION
This pull request refactors the `ToPascalCase` method by moving it from `JsonDocumentExtensions` to a new `StringExtensions` class, improving code organization and enabling reuse. Additionally, it updates the usage of this method in `JsonDocumentExtensions`.

### Refactoring and Code Organization:

* Removed the `ToPascalCase` method from `JsonDocumentExtensions` and added it as an extension method in a new `StringExtensions` class to improve modularity and reusability. (`src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.cs` [[1]](diffhunk://#diff-c7d22356efcd0d29ff9b168ee1f90049fed7b21804b6a1980bcd947988107882L74-L105) `src/PdfSmith.BusinessLayer/Extensions/StringExtensions.cs` [[2]](diffhunk://#diff-693dd581cbf651c4e83d52079efaf10de99ba744c3fb3444ed9fde89b4fbed07R1-R38)

### Code Updates:

* Updated the usage of the `ToPascalCase` method in `ConvertElement` to call the new extension method using the string instance. (`src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.cs` [src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.csL21-R20](diffhunk://#diff-c7d22356efcd0d29ff9b168ee1f90049fed7b21804b6a1980bcd947988107882L21-R20))

### Cleanup:

* Removed the unused `System.Text` namespace import from `JsonDocumentExtensions`. (`src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.cs` [src/PdfSmith.BusinessLayer/Extensions/JsonDocumentExtensions.csL4](diffhunk://#diff-c7d22356efcd0d29ff9b168ee1f90049fed7b21804b6a1980bcd947988107882L4))

Closes #2 