### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy on Azure
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/marcominerva/PdfSmith/security/code-scanning/1](https://github.com/marcominerva/PdfSmith/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents to build and deploy the application.

The `permissions` block will be added after the `name` field at the top of the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
